### PR TITLE
Fix client initialization

### DIFF
--- a/GameAnalyticsSDK/GameAnalytics/Logger.lua
+++ b/GameAnalyticsSDK/GameAnalytics/Logger.lua
@@ -26,7 +26,7 @@ function logger:i(format)
 
 	local m = "Info/GameAnalytics: " .. format
 	print(m)
---    GameAnalyticsSendMessage = GameAnalyticsSendMessage or game:GetService("ReplicatedStorage"):WaitForChild("GameAnalyticsSendMessage")
+--    GameAnalyticsSendMessage = GameAnalyticsSendMessage or game:GetService("ReplicatedStorage"):WaitForChild("GameAnalyticsEvents"):WaitForChild("GameAnalyticsSendMessage")
 --    GameAnalyticsSendMessage:FireAllClients({
 --        Text = m,
 --        Font = Enum.Font.Arial,
@@ -38,7 +38,7 @@ end
 function logger:w(format)
 	local m = "Warning/GameAnalytics: " .. format
 	warn(m)
---    GameAnalyticsSendMessage = GameAnalyticsSendMessage or game:GetService("ReplicatedStorage"):WaitForChild("GameAnalyticsSendMessage")
+--    GameAnalyticsSendMessage = GameAnalyticsSendMessage or game:GetService("ReplicatedStorage"):WaitForChild("GameAnalyticsEvents"):WaitForChild("GameAnalyticsSendMessage")
 --    GameAnalyticsSendMessage:FireAllClients({
 --        Text = m,
 --        Font = Enum.Font.Arial,

--- a/GameAnalyticsSDK/GameAnalytics/Postie.lua
+++ b/GameAnalyticsSDK/GameAnalytics/Postie.lua
@@ -53,24 +53,24 @@
 
 local HttpService = game:GetService("HttpService")
 local RunService = game:GetService("RunService")
-local replicatedStorage = game:GetService("ReplicatedStorage")
+local remoteEvents = game:GetService("ReplicatedStorage"):WaitForChild("GameAnalyticsEvents")
 
-if not replicatedStorage:FindFirstChild("PostieSent") then
+if not remoteEvents:FindFirstChild("PostieSent") then
 	--Create
 	local f = Instance.new("RemoteEvent")
 	f.Name = "PostieSent"
-	f.Parent = replicatedStorage
+	f.Parent = remoteEvents
 end
 
-if not replicatedStorage:FindFirstChild("PostieReceived") then
+if not remoteEvents:FindFirstChild("PostieReceived") then
 	--Create
 	local f = Instance.new("RemoteEvent")
 	f.Name = "PostieReceived"
-	f.Parent = replicatedStorage
+	f.Parent = remoteEvents
 end
 
-local sent = replicatedStorage.PostieSent -- RemoteEvent
-local received = replicatedStorage.PostieReceived -- RemoteEvent
+local sent = remoteEvents.PostieSent -- RemoteEvent
+local received = remoteEvents.PostieReceived -- RemoteEvent
 
 local isServer = RunService:IsServer()
 local callbackById = {}

--- a/GameAnalyticsSDK/GameAnalytics/State.lua
+++ b/GameAnalyticsSDK/GameAnalytics/State.lua
@@ -60,7 +60,7 @@ local function populateConfigurations(player)
 	logger:i("Remote configs populated")
 
 	PlayerData.RemoteConfigsIsReady = true
-	GameAnalyticsRemoteConfigs = GameAnalyticsRemoteConfigs or game:GetService("ReplicatedStorage"):WaitForChild("GameAnalyticsRemoteConfigs")
+	GameAnalyticsRemoteConfigs = GameAnalyticsRemoteConfigs or game:GetService("ReplicatedStorage"):WaitForChild("GameAnalyticsEvents"):WaitForChild("GameAnalyticsRemoteConfigs")
 	GameAnalyticsRemoteConfigs:FireClient(player, PlayerData.Configurations)
 end
 

--- a/GameAnalyticsSDK/GameAnalytics/init.lua
+++ b/GameAnalyticsSDK/GameAnalytics/init.lua
@@ -20,7 +20,6 @@ local MKT = game:GetService("MarketplaceService")
 local RunService = game:GetService("RunService")
 local LocalizationService = game:GetService("LocalizationService")
 local ScriptContext = game:GetService("ScriptContext")
-local Postie = require(script.Postie)
 local OnPlayerReadyEvent
 local ProductCache = {}
 local ONE_HOUR_IN_SECONDS = 3600
@@ -38,6 +37,10 @@ do
 	RemoteEvents.Name = "GameAnalyticsEvents"
 	RemoteEvents.Parent = game:GetService("ReplicatedStorage")
 end
+
+-- must be required after
+local Postie = require(script.Postie)
+
 
 local function addToInitializationQueue(func, ...)
 	if InitializationQueue ~= nil then

--- a/GameAnalyticsSDK/GameAnalyticsClient/Postie.lua
+++ b/GameAnalyticsSDK/GameAnalyticsClient/Postie.lua
@@ -54,23 +54,24 @@
 local HttpService = game:GetService("HttpService")
 local RunService = game:GetService("RunService")
 local replicatedStorage = game:GetService("ReplicatedStorage")
+local remoteEvents = replicatedStorage:WaitForChild("GameAnalyticsEvents")
 
-if not replicatedStorage:FindFirstChild("PostieSent") then
+if not remoteEvents:FindFirstChild("PostieSent") then
 	--Create
 	local f = Instance.new("RemoteEvent")
 	f.Name = "PostieSent"
-	f.Parent = replicatedStorage
+	f.Parent = remoteEvents
 end
 
-if not replicatedStorage:FindFirstChild("PostieReceived") then
+if not remoteEvents:FindFirstChild("PostieReceived") then
 	--Create
 	local f = Instance.new("RemoteEvent")
 	f.Name = "PostieReceived"
-	f.Parent = replicatedStorage
+	f.Parent = remoteEvents
 end
 
-local sent = replicatedStorage.PostieSent -- RemoteEvent
-local received = replicatedStorage.PostieReceived -- RemoteEvent
+local sent = remoteEvents.PostieSent -- RemoteEvent
+local received = remoteEvents.PostieReceived -- RemoteEvent
 
 local isServer = RunService:IsServer()
 local callbackById = {}

--- a/GameAnalyticsSDK/GameAnalyticsClient/init.lua
+++ b/GameAnalyticsSDK/GameAnalyticsClient/init.lua
@@ -36,6 +36,6 @@ local function getPlatform()
 end
 
 --Filtering
-Postie.SetCallback("getPlatform", getPlatform)
+Postie.setCallback("getPlatform", getPlatform)
 
 return 0 -- Return exactly one value so require() doesn't error

--- a/GameAnalyticsSDK/GameAnalyticsClient/init.lua
+++ b/GameAnalyticsSDK/GameAnalyticsClient/init.lua
@@ -4,9 +4,9 @@
 --Services
 local GS = game:GetService("GuiService")
 local UIS = game:GetService("UserInputService")
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Postie = require(script.Postie)
 local ScriptContext = game:GetService("ScriptContext")
+local RemoteEvents = game:GetService("ReplicatedStorage"):WaitForChild("GameAnalyticsEvents")
 
 ScriptContext.Error:Connect(function(message, stackTrace, scriptInst)
 	if not scriptInst then
@@ -21,7 +21,7 @@ ScriptContext.Error:Connect(function(message, stackTrace, scriptInst)
 		return
 	end
 
-	ReplicatedStorage.GameAnalyticsError:FireServer(message, stackTrace, scriptName)
+	RemoteEvents.GameAnalyticsError:FireServer(message, stackTrace, scriptName)
 end)
 
 --Functions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,8 @@
 {
 	"name": "@rbxts/gameanalytics",
 	"version": "2.1.35-ts1",
-	"lockfileVersion": 2,
+	"lockfileVersion": 1,
 	"requires": true,
-	"packages": {
-		"": {
-			"name": "@rbxts/gameanalytics",
-			"version": "2.1.35-ts1",
-			"license": "MIT",
-			"devDependencies": {
-				"@rbxts/compiler-types": "^1.2.9-types.0",
-				"@rbxts/types": "^1.0.571"
-			}
-		},
-		"node_modules/@rbxts/compiler-types": {
-			"version": "1.2.9-types.0",
-			"resolved": "https://registry.npmjs.org/@rbxts/compiler-types/-/compiler-types-1.2.9-types.0.tgz",
-			"integrity": "sha512-VnneeBGTXgtcAGpAiOrOyzdMLV3yOFBdbxcM2pZhXJw4NswvSRY2ZtLudXmeivlhgXPscjZlFZE1Uf2FD8tM4A==",
-			"dev": true
-		},
-		"node_modules/@rbxts/types": {
-			"version": "1.0.571",
-			"resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.571.tgz",
-			"integrity": "sha512-VKBktp/GefC8uHzzRhZJE8EhQw6Zq2oMzc8dlWoaj2xe6rT2bWllYg4pl7tuw29LjaUuIqWm0GUhbSqMiKmmaQ==",
-			"dev": true
-		}
-	},
 	"dependencies": {
 		"@rbxts/compiler-types": {
 			"version": "1.2.9-types.0",


### PR DESCRIPTION
There is an issue with calling the client initialization where it'd throw an error due to a typo setting the postie callback. Additionally I made a simple change to the SDK to make the events be stored in a folder, rather than the replicated storage root, this is more of a personal thing, but I thought I'd include it anyway.